### PR TITLE
fix ldflags for Windows build script

### DIFF
--- a/build_script/main.go
+++ b/build_script/main.go
@@ -57,7 +57,7 @@ func build() {
 		// The -H=windowsgui -ldflag is to make sure Go builds a Windows GUI app so the command prompt doesn't stay
 		// open while MasterPlan is running. It has to be only if you're building on Windows because this flag
 		// gets passed to the compiler and XCode wouldn't build if on Mac I leave it in there.
-		args = []string{"build", "-ldflags", "-X main.releaseMode=true", "-H=windowsgui", "-o", filename, "./"}
+		args = []string{"build", "-ldflags=-X main.releaseMode=true -H=windowsgui", "-o", filename, "./"}
 	}
 
 	log.Println("Building binary...")


### PR DESCRIPTION
When manually building the binary on Windows 10 Education (64 bit), I get this error message:
```
$ go run ./build_script/main.go -b
2020/06/26 11:01:14 Assets copied.
2020/06/26 11:01:14 Building binary...
2020/06/26 11:01:14 flag provided but not defined: -H
usage: go build [-o output] [-i] [build flags] [packages]
Run 'go help build' for details.
```

The issue seems to be the `"-ldflags", "-X main.releaseMode=true", "-H=windowsgui"` args on line **60** in **build_script/main.go**.
It recognizes `-X main.releaseMode=true` as a linker flag but not `-H=windowsgui`.

The solution I found is to combine the arguments:
`"-ldflags=-X main.releaseMode=true -H=windowsgui"`