### PR TITLE
Added Ability to Open File from CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"path/filepath"
 
 	"github.com/blang/semver"
 	rl "github.com/gen2brain/raylib-go/raylib"
@@ -161,7 +162,12 @@ func main() {
 			attemptAutoload--
 
 			if attemptAutoload == 0 {
-				if programSettings.AutoloadLastPlan && len(programSettings.RecentPlanList) > 0 {
+				//loads file when passed in as argument
+				if len(os.Args) > 1 && strings.EqualFold(filepath.Ext(os.Args[1]), ".plan") {
+					if loaded := LoadProject(os.Args[1]); loaded != nil {
+						currentProject = loaded
+					}
+				} else if programSettings.AutoloadLastPlan && len(programSettings.RecentPlanList) > 0 {
 					if loaded := LoadProject(programSettings.RecentPlanList[0]); loaded != nil {
 						currentProject = loaded
 					}


### PR DESCRIPTION
Hey SolarLune!

I was using MasterPlan as the default program for .plan files in Windows, and found that it didn't handle opening files from the command line (or double click).

I added some simple lines in main.go to load a proper .plan file from the second argument spot.

Feature Demo:
![MasterPlanDemo](https://user-images.githubusercontent.com/15825445/87744726-337e9680-c7ba-11ea-876d-1b80e9600646.gif)