### PR TITLE
changing board names construction to something supported by sjson

### DIFF
--- a/project.go
+++ b/project.go
@@ -351,11 +351,10 @@ func (project *Project) Save(backup bool) {
 				project.Locked = true
 			}
 
-			boardNames := []string{}
-			for _, board := range project.Boards {
-				boardNames = append(boardNames, board.Name)
+			sjson.SetRaw(data, `BoardNames`, "[]")
+			for i, board := range project.Boards {
+				data, _ = sjson.Set(data, "BoardNames." + fmt.Sprintf("%d", i), board.Name)
 			}
-			sjson.Set(data, `BoardNames`, boardNames)
 
 			f, err := os.Create(project.FilePath)
 			if err != nil {


### PR DESCRIPTION
Board names currently don't get saved correctly due to sjson seemingly not supporting array primitives at first glance.

Changing the construction method of boards to be raw and use the sjson array access string structure (can be seen on their readme).