### PR TITLE
Resolve paths relative to the project file.

### DIFF
--- a/project.go
+++ b/project.go
@@ -2176,6 +2176,10 @@ func (project *Project) LoadResource(resourcePath string) (*Resource, bool) {
 
 		localFilepath := resourcePath
 
+		if strings.HasPrefix(resourcePath, "./") || strings.HasPrefix(resourcePath, "../") {
+			localFilepath = filepath.Join(filepath.Dir(project.FilePath), localFilepath)
+		}
+
 		// Attempt downloading it if it's an HTTP file
 		if strings.HasPrefix(resourcePath, "http://") || strings.HasPrefix(resourcePath, "https://") {
 
@@ -2300,3 +2304,4 @@ func (project *Project) ExecuteDestructiveAction(action string, argument string)
 	}
 
 }
+


### PR DESCRIPTION
If the resourcePath is prefixed with "./" or "../", prepend the location of
the project file to the localFilepath. This helps make cloning projects
portable across multiple devices.

I currently don't have a Windows installation, but I don't believe
this would conflict with any Windows paths.