### PR TITLE
Serialize paths relative to the project file.

### DIFF
--- a/task.go
+++ b/task.go
@@ -357,7 +357,7 @@ func (task *Task) Serialize() string {
 
 		if resource, _ := task.Board.Project.LoadResource(resourcePath); resource != nil && !resource.Temporary {
 
-			relative, err := filepath.Rel(WorkingDirectory(), resourcePath)
+			relative, err := filepath.Rel(filepath.Dir(task.Board.Project.FilePath), resourcePath)
 
 			if err == nil {
 


### PR DESCRIPTION
Hi!

Sorry, about creating that other pull-request. I thought that the relative-path feature was not implemented. Upon further inspection, I saw it mentioned within commit messages.

Afterwards, I noticed that MasterPlan wasn't loading images on reload of projects. It looks like it is serializing the paths relative to the CWD instead of the project file. Then it attempts to de-serialize the path relative to the project file.