### PR TITLE
add per project option to set a custom screenshots path

### DIFF
--- a/common.go
+++ b/common.go
@@ -64,6 +64,15 @@ func GetPath(folders ...string) string {
 
 }
 
+func ValidatePath(path, filename, fallback string) string {
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fallback
+	}
+
+	return filepath.Join(path, filename)
+}
+
 func WorkingDirectory() string {
 
 	workingDirectory := ""

--- a/common.go
+++ b/common.go
@@ -64,15 +64,6 @@ func GetPath(folders ...string) string {
 
 }
 
-func ValidatePath(path, filename, fallback string) string {
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fallback
-	}
-
-	return filepath.Join(path, filename)
-}
-
 func WorkingDirectory() string {
 
 	workingDirectory := ""

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -284,8 +285,10 @@ func main() {
 				screenshotIndex++
 				screenshotFileName := fmt.Sprintf("screenshot%d.png", screenshotIndex)
 				screenshotPath := GetPath(screenshotFileName)
-				if programSettings.ScreenshotsPath != "" {
-					screenshotPath = ValidatePath(programSettings.ScreenshotsPath, screenshotFileName, screenshotPath)
+				if projectScreenshotsPath := currentProject.ScreenshotsPath.Text(); projectScreenshotsPath != "" {
+					if _, err := os.Stat(projectScreenshotsPath); err == nil {
+						screenshotPath = filepath.Join(projectScreenshotsPath, screenshotFileName)
+					}
 				}
 				rl.TakeScreenshot(screenshotPath)
 				takeScreenshot = false

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 		}
 
 		clearColor := getThemeColor(GUI_INSIDE_DISABLED)
-		
+
 		if windowFlags&byte(rl.FlagWindowTransparent) > 0 {
 			clearColor = rl.Color{}
 		}
@@ -282,7 +282,12 @@ func main() {
 			if takeScreenshot {
 				currentProject.Log("Screenshot saved successfully.")
 				screenshotIndex++
-				rl.TakeScreenshot(GetPath(fmt.Sprintf("screenshot%d.png", screenshotIndex)))
+				screenshotFileName := fmt.Sprintf("screenshot%d.png", screenshotIndex)
+				screenshotPath := GetPath(screenshotFileName)
+				if programSettings.ScreenshotsPath != "" {
+					screenshotPath = ValidatePath(programSettings.ScreenshotsPath, screenshotFileName, screenshotPath)
+				}
+				rl.TakeScreenshot(screenshotPath)
 				takeScreenshot = false
 			}
 

--- a/programSettings.go
+++ b/programSettings.go
@@ -7,14 +7,15 @@ import (
 )
 
 type ProgramSettings struct {
+	RecentPlanList            []string
+	TargetFPS                 int
+	ScreenshotsPath           string
 	AutoloadLastPlan          bool
 	AutoReloadThemes          bool
-	RecentPlanList            []string
 	DisableSplashscreen       bool
 	DisableMessageLog         bool
 	DisableAboutDialogOnStart bool
 	AutoReloadResources       bool
-	TargetFPS                 int
 	TransparentBackground     bool
 	BorderlessWindow          bool
 }

--- a/project.go
+++ b/project.go
@@ -283,6 +283,10 @@ func NewProject() *Project {
 	row.Item(NewLabel("Maximum Undo Steps:"), SETTINGS_GENERAL)
 	row.Item(project.MaxUndoSteps, SETTINGS_GENERAL)
 
+	row = column.Row()
+	row.Item(NewLabel("Screenshots Path:"), SETTINGS_GENERAL)
+	row.Item(project.ScreenshotsPath, SETTINGS_GENERAL)
+
 	// TASKS
 
 	row = column.Row()
@@ -362,10 +366,6 @@ func NewProject() *Project {
 	row = column.Row()
 	row.Item(NewLabel("Target FPS:"), SETTINGS_GLOBAL)
 	row.Item(project.TargetFPS, SETTINGS_GLOBAL)
-
-	row = column.Row()
-	row.Item(NewLabel("Screenshots Path:"), SETTINGS_GLOBAL)
-	row.Item(project.ScreenshotsPath, SETTINGS_GLOBAL)
 
 	row = column.Row()
 	row.Item(NewLabel("Automatically reload changed\nlocal resources (experimental!):"), SETTINGS_GLOBAL)
@@ -582,6 +582,7 @@ func (project *Project) Save(backup bool) {
 			data, _ = sjson.Set(data, `IncompleteTasksGlow`, project.IncompleteTasksGlow.Checked)
 			data, _ = sjson.Set(data, `CompleteTasksGlow`, project.CompleteTasksGlow.Checked)
 			data, _ = sjson.Set(data, `SelectedTasksGlow`, project.SelectedTasksGlow.Checked)
+			data, _ = sjson.Set(data, `ScreenshotsPath`, project.ScreenshotsPath.Text())
 
 			boardNames := []string{}
 			for _, board := range project.Boards {
@@ -2036,7 +2037,6 @@ func (project *Project) GUI() {
 				programSettings.DisableAboutDialogOnStart = project.DisableAboutDialogOnStart.Checked
 				programSettings.AutoReloadResources = project.AutoReloadResources.Checked
 				programSettings.TargetFPS = project.TargetFPS.Number()
-				programSettings.ScreenshotsPath = project.ScreenshotsPath.Text()
 				programSettings.BorderlessWindow = project.BorderlessWindow.Checked
 				programSettings.TransparentBackground = project.TransparentBackground.Checked
 

--- a/project.go
+++ b/project.go
@@ -115,6 +115,7 @@ type Project struct {
 	TargetFPS                 *NumberSpinner
 	TransparentBackground     *Checkbox
 	BorderlessWindow          *Checkbox
+	ScreenshotsPath           *Textbox
 
 	// Internal data to make stuff work
 	FilePath            string
@@ -223,6 +224,7 @@ func NewProject() *Project {
 		DisableMessageLog:   NewCheckbox(0, 0, 32, 32),
 		AutoReloadResources: NewCheckbox(0, 0, 32, 32),
 		TargetFPS:           NewNumberSpinner(0, 0, 128, 40),
+		ScreenshotsPath:     NewTextbox(0, 0, 32, 32),
 
 		AboutDiscordButton:        NewButton(0, 0, 128, 24, "Discord", false),
 		AboutForumsButton:         NewButton(0, 0, 128, 24, "Forums", false),
@@ -360,6 +362,10 @@ func NewProject() *Project {
 	row = column.Row()
 	row.Item(NewLabel("Target FPS:"), SETTINGS_GLOBAL)
 	row.Item(project.TargetFPS, SETTINGS_GLOBAL)
+
+	row = column.Row()
+	row.Item(NewLabel("Screenshots Path:"), SETTINGS_GLOBAL)
+	row.Item(project.ScreenshotsPath, SETTINGS_GLOBAL)
 
 	row = column.Row()
 	row.Item(NewLabel("Automatically reload changed\nlocal resources (experimental!):"), SETTINGS_GLOBAL)
@@ -2030,6 +2036,7 @@ func (project *Project) GUI() {
 				programSettings.DisableAboutDialogOnStart = project.DisableAboutDialogOnStart.Checked
 				programSettings.AutoReloadResources = project.AutoReloadResources.Checked
 				programSettings.TargetFPS = project.TargetFPS.Number()
+				programSettings.ScreenshotsPath = project.ScreenshotsPath.Text()
 				programSettings.BorderlessWindow = project.BorderlessWindow.Checked
 				programSettings.TransparentBackground = project.TransparentBackground.Checked
 


### PR DESCRIPTION
Hi @SolarLune 

This PR adds a per-project option to setup a custom screenshot output directory (if set). It also includes a fallback so in case that the directory does not exists it uses the application path directory as usual.

Regards