### PR TITLE
Use XDG Base Directory Specification for logs and settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/solarlune/masterplan
 go 1.13
 
 require (
+	github.com/adrg/xdg v0.2.3
 	github.com/atotto/clipboard v0.1.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/chonla/roman-number-go v0.0.0-20181101035413-6768129de021

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/adrg/xdg v0.2.3 h1:GxXngdYxNDkoUvZXjNJGwqZxWXi43MKbOOlA/00qZi4=
+github.com/adrg/xdg v0.2.3/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/blang/semver"
 	rl "github.com/gen2brain/raylib-go/raylib"
+	"github.com/adrg/xdg"
 )
 
 // Build-time variable
@@ -41,7 +42,12 @@ func init() {
 
 		// Redirect STDERR and STDOUT to log.txt in release mode
 
-		f, err := os.Create(GetPath("log.txt"))
+		logPath := filepath.FromSlash(xdg.DataHome + "/MasterPlan/log.txt")
+		err := os.MkdirAll(filepath.Dir(logPath), os.ModePerm)
+		if err != nil {
+			panic(err)
+		}
+		f, err := os.Create(logPath)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -42,8 +42,7 @@ func init() {
 
 		// Redirect STDERR and STDOUT to log.txt in release mode
 
-		logPath := filepath.FromSlash(xdg.DataHome + "/MasterPlan/log.txt")
-		err := os.MkdirAll(filepath.Dir(logPath), os.ModePerm)
+		logPath, err := xdg.DataFile("MasterPlan/log.txt")
 		if err != nil {
 			panic(err)
 		}

--- a/programSettings.go
+++ b/programSettings.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	SETTINGS_FILENAME    = "settings.json"
-	SETTINGS_DIRNAME     = "MasterPlan"
-	SETTINGS_PATH        = SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
+	SETTINGS_PATH        = "MasterPlan/settings.json"
 	SETTINGS_LEGACY_PATH = "masterplan-settings.json"
 )
 

--- a/programSettings.go
+++ b/programSettings.go
@@ -15,6 +15,7 @@ const (
 	SETTINGS_FILENAME = "masterplan-settings.json"
 	SETTINGS_DIRNAME = "MasterPlan"
 	SETTINGS_PATH = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
+	SETTINGS_LEGACY_PATH = SETTINGS_FILENAME
 )
 
 type ProgramSettings struct {
@@ -69,6 +70,10 @@ func (ps *ProgramSettings) Save() {
 func (ps *ProgramSettings) Load() {
 	path := filepath.FromSlash(xdg.ConfigHome + SETTINGS_PATH)
 	settingsJSON, err := ioutil.ReadFile(path)
+	if err != nil {
+		// Trying to read legacy path.
+		settingsJSON, err = ioutil.ReadFile(GetPath(SETTINGS_LEGACY_PATH))
+	}
 	if err == nil {
 		json.Unmarshal(settingsJSON, ps)
 	}

--- a/programSettings.go
+++ b/programSettings.go
@@ -2,11 +2,19 @@ package main
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"io/ioutil"
 	"os"
 
 	rl "github.com/gen2brain/raylib-go/raylib"
 	"github.com/tidwall/gjson"
+	"github.com/adrg/xdg"
+)
+
+const (
+	SETTINGS_FILENAME = "masterplan-settings.json"
+	SETTINGS_DIRNAME = "MasterPlan"
+	SETTINGS_PATH = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
 )
 
 type ProgramSettings struct {
@@ -47,7 +55,9 @@ func (ps *ProgramSettings) CleanUpRecentPlanList() {
 }
 
 func (ps *ProgramSettings) Save() {
-	f, err := os.Create(GetPath("masterplan-settings.json")) // Use GetPath to ensure it's coming from the home directory, not somewhere else
+	path := filepath.FromSlash(xdg.ConfigHome + SETTINGS_PATH)
+	os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	f, err := os.Create(path)
 	if err == nil {
 		defer f.Close()
 		bytes, _ := json.Marshal(ps)
@@ -57,7 +67,8 @@ func (ps *ProgramSettings) Save() {
 }
 
 func (ps *ProgramSettings) Load() {
-	settingsJSON, err := ioutil.ReadFile(GetPath("masterplan-settings.json"))
+	path := filepath.FromSlash(xdg.ConfigHome + SETTINGS_PATH)
+	settingsJSON, err := ioutil.ReadFile(path)
 	if err == nil {
 		json.Unmarshal(settingsJSON, ps)
 	}

--- a/programSettings.go
+++ b/programSettings.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SETTINGS_FILENAME = "masterplan-settings.json"
+	SETTINGS_FILENAME = "settings.json"
 	SETTINGS_DIRNAME = "MasterPlan"
 	SETTINGS_PATH = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
 	SETTINGS_LEGACY_PATH = SETTINGS_FILENAME

--- a/programSettings.go
+++ b/programSettings.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	SETTINGS_FILENAME = "settings.json"
-	SETTINGS_DIRNAME = "MasterPlan"
-	SETTINGS_PATH = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
+	SETTINGS_FILENAME    = "settings.json"
+	SETTINGS_DIRNAME     = "MasterPlan"
+	SETTINGS_PATH        = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
 	SETTINGS_LEGACY_PATH = "masterplan-settings.json"
 )
 

--- a/programSettings.go
+++ b/programSettings.go
@@ -15,7 +15,7 @@ const (
 	SETTINGS_FILENAME = "settings.json"
 	SETTINGS_DIRNAME = "MasterPlan"
 	SETTINGS_PATH = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
-	SETTINGS_LEGACY_PATH = SETTINGS_FILENAME
+	SETTINGS_LEGACY_PATH = "masterplan-settings.json"
 )
 
 type ProgramSettings struct {

--- a/programSettings.go
+++ b/programSettings.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"path/filepath"
 	"io/ioutil"
 	"os"
 
@@ -14,7 +13,7 @@ import (
 const (
 	SETTINGS_FILENAME    = "settings.json"
 	SETTINGS_DIRNAME     = "MasterPlan"
-	SETTINGS_PATH        = "/" + SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
+	SETTINGS_PATH        = SETTINGS_DIRNAME + "/" + SETTINGS_FILENAME
 	SETTINGS_LEGACY_PATH = "masterplan-settings.json"
 )
 
@@ -56,8 +55,7 @@ func (ps *ProgramSettings) CleanUpRecentPlanList() {
 }
 
 func (ps *ProgramSettings) Save() {
-	path := filepath.FromSlash(xdg.ConfigHome + SETTINGS_PATH)
-	os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	path, _ := xdg.ConfigFile(SETTINGS_PATH)
 	f, err := os.Create(path)
 	if err == nil {
 		defer f.Close()
@@ -68,7 +66,7 @@ func (ps *ProgramSettings) Save() {
 }
 
 func (ps *ProgramSettings) Load() {
-	path := filepath.FromSlash(xdg.ConfigHome + SETTINGS_PATH)
+	path, _ := xdg.ConfigFile(SETTINGS_PATH)
 	settingsJSON, err := ioutil.ReadFile(path)
 	if err != nil {
 		// Trying to read legacy path.


### PR DESCRIPTION
Currently, the program writes log and setting files to the same directory where the binary is, which is generally considered a bad practice, because binaries are usually installed to system directories (such as `C:\Program Files` or `/usr/bin`), and users would need administrator privileges to write to those files. Even if this is circumvented somehow, all users would share same settings file, which is not good either.

[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) defines common environment variables for programs to adhere, that users can set however they wish, and if not set, fallback to reasonable system defaults.

This branch makes use of [adrg/xdg](https://github.com/adrg/xdg) Go package and sets the following default paths for log and settings file:

For `log.txt`:
- `XDG_DATA_HOME/MasterPlan`
- or `C:\users\%USERNAME%\AppData\Local\MasterPlan` (on Windows)
- or `~/.local/share/MasterPlan` (on Linux)
- or `~/Library/Application Support/MasterPlan` (on Mac)
- or `./` (Legacy)

For `masterplan-settings.json`:
- `XDG_CONFIG_HOME/MasterPlan`
- or `C:\users\%USERNAME%\AppData\Local\MasterPlan` (on Windows)
- or `~/.config/MasterPlan` (on Linux)
- or `~/Library/Preferences/MasterPlan` (on Mac)
- or `./` (Legacy)

Also, if settings file is not present at the new path, the program will try to read settings from old location (legacy `./`), allowing seamless transition for existing users.