### PR TITLE
Don't allow numbered cards to have negative tasks completed

### DIFF
--- a/contents.go
+++ b/contents.go
@@ -387,6 +387,8 @@ func NewNumberedContents(card *Card) *NumberedContents {
 
 	current := card.Properties.Get("current")
 	numbered.Current = NewNumberSpinner(nil, true, current)
+	// Don't allow negative numbers of tasks completed
+	numbered.Current.SetLimits(0, math.MaxFloat64)
 
 	max := card.Properties.Get("maximum")
 	numbered.Max = NewNumberSpinner(nil, true, max)


### PR DESCRIPTION
Currently, if you press - on a numbered card, you can have a negative number for the amount of completed tasks
This is a one-line change, it should be pretty self-explanatory