### PR TITLE
Fix text rendering artifacts

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -1640,7 +1640,9 @@ func (label *Label) Draw() {
 		}
 
 		src := &sdl.Rect{0, 0, w, h}
-		newRect := &sdl.FRect{label.Rect.X + label.Offset.X, label.Rect.Y + label.Offset.Y, float32(w), float32(h)}
+
+		// Floor the rectangle to avoid aliasing artifacts when rendering with nearest neighbour
+		newRect := &sdl.FRect{float32(math.Floor(float64(label.Rect.X + label.Offset.X))), float32(math.Floor(float64(label.Rect.Y + label.Offset.Y))), float32(w), float32(h)}
 
 		// newRect.Y -= baseline // Center it
 

--- a/main.go
+++ b/main.go
@@ -700,6 +700,46 @@ func main() {
 
 }
 
+func unambiguousPathName(path string, paths []string) string {
+	splitPath := strings.Split(path, string(os.PathSeparator))
+	currentPath := ""
+
+	// Avoid exact same path `path` in `paths` list
+	var newPaths []string
+	for _, otherPath := range paths {
+		if path != otherPath {
+			newPaths = append(newPaths, otherPath)
+		}
+	}
+
+	for at := range splitPath {
+		myTail := len(splitPath)-at
+		currentPath = strings.Join(splitPath[myTail:], string(os.PathSeparator))
+		found := false
+
+		for _, otherPath := range newPaths {
+
+			otherPathSplit := strings.Split(otherPath, string(os.PathSeparator))
+			otherTail := len(otherPathSplit)-at
+			if otherTail < 0 {
+				continue
+			}
+
+			otherPathSliced := strings.Join(otherPathSplit[otherTail:], string(os.PathSeparator))
+			if currentPath == otherPathSliced {
+				fmt.Printf("Same path: %v %v", currentPath, otherPathSliced)
+				found = true
+			}
+		}
+
+		if !found {
+			break
+		}
+	}
+	return currentPath
+}
+
+
 func ConstructMenus() {
 
 	// Main Menu
@@ -849,8 +889,9 @@ func ConstructMenus() {
 			for i, recentName := range globals.RecentFiles {
 				recent := recentName // We have to do this so it points to the correct variable, again
 				row = root.AddRow(AlignLeft)
-				_, filename := filepath.Split(recent)
-				row.Add("", NewButton(strconv.Itoa(i+1)+": "+filename, nil, nil, false, func() {
+				path := unambiguousPathName(recentName, globals.RecentFiles)
+
+				row.Add("", NewButton(strconv.Itoa(i+1)+": "+path, nil, nil, false, func() {
 					globals.Project.LoadConfirmationTo = recent
 					loadConfirm := globals.MenuSystem.Get("confirm load")
 					loadConfirm.Center()

--- a/textrenderer.go
+++ b/textrenderer.go
@@ -173,7 +173,8 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 	result.Image = renderTexture
 
 	renderTexture.RenderFunc = func() {
-
+		hint := sdl.GetHint(sdl.HINT_RENDER_SCALE_QUALITY)
+		sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, "2")
 		finalW := globals.GridSize
 
 		x := 0
@@ -257,6 +258,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 		}
 
+		sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, hint)
 		result.TextLines = append(result.TextLines, line)
 		result.TextSize.X = finalW
 		result.TextSize.Y = float32(math.Max(float64(globals.GridSize), float64(len(result.TextLines)*int(globals.GridSize))))


### PR DESCRIPTION
Removes weird rendering artifacts:
![image](https://user-images.githubusercontent.com/27076041/154709573-0ad80381-480e-456e-a79f-3deb4013f088.png)
I hope I didn't mess anything up because I don't have a lot of experience with Go