### PR TITLE
Make arrow keys move the caret to the start or end of a selection

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -1867,7 +1867,7 @@ func (label *Label) Draw() {
 			pos = globals.Project.Camera.TranslatePoint(pos)
 		}
 
-		if math.Sin(globals.Time*(math.Pi*4)) > 0 {
+		if label.Selection.Length() == 0 && math.Sin(globals.Time*(math.Pi*4)) > 0 {
 			ThickLine(pos, pos.Add(Point{0, globals.GridSize}), 4, getThemeColor(GUIFontColor))
 		}
 

--- a/gui.go
+++ b/gui.go
@@ -1372,7 +1372,12 @@ func (label *Label) Update() {
 					if globals.Keyboard.Key(sdl.K_LSHIFT).Held() {
 						label.Selection.Select(label.Selection.Start, label.Selection.End+advance)
 					} else {
-						label.Selection.AdvanceCaret(advance)
+						if label.Selection.Length() == 0 {
+							label.Selection.AdvanceCaret(advance)
+						} else {
+							_, end := label.Selection.ContiguousRange()
+							label.Selection.Select(end, end)
+						}
 					}
 				}
 
@@ -1406,7 +1411,12 @@ func (label *Label) Update() {
 					if globals.Keyboard.Key(sdl.K_LSHIFT).Held() {
 						label.Selection.Select(label.Selection.Start, label.Selection.End+advance)
 					} else {
-						label.Selection.AdvanceCaret(advance)
+						if label.Selection.Length() == 0 {
+							label.Selection.AdvanceCaret(advance)
+						} else {
+							start, _ := label.Selection.ContiguousRange()
+							label.Selection.Select(start, start)
+						}
 					}
 				}
 


### PR DESCRIPTION
Previously, moving the caret while a selection was open had no special effect - it would only cancel the solution, and move the caret left or right one char
Now, it is more comparable to other text selections, by placing the caret at the start or end of the selection appropriately.

Also, hide the caret if a selection is currently open