### PR TITLE
Font supersampling - blurry text fix

### DIFF
--- a/common.go
+++ b/common.go
@@ -360,7 +360,7 @@ func HandleFontReload() {
 			// For silver.ttf, 21 is the ideal font size. Otherwise, 30 seems to be reasonable.
 
 			// loadedFont, err := ttf.OpenFont(fontPath, int(globals.Settings.Get(SettingsFontSize).AsFloat()))
-			loadedFont, err := ttf.OpenFont(fontPath, 48)
+			loadedFont, err := ttf.OpenFont(fontPath, 96)
 
 			if err != nil {
 				panic(err)

--- a/common.go
+++ b/common.go
@@ -360,7 +360,7 @@ func HandleFontReload() {
 			// For silver.ttf, 21 is the ideal font size. Otherwise, 30 seems to be reasonable.
 
 			// loadedFont, err := ttf.OpenFont(fontPath, int(globals.Settings.Get(SettingsFontSize).AsFloat()))
-			loadedFont, err := ttf.OpenFont(fontPath, 96)
+			loadedFont, err := ttf.OpenFont(fontPath, 128)
 
 			if err != nil {
 				panic(err)

--- a/globals.go
+++ b/globals.go
@@ -51,6 +51,7 @@ type Globals struct {
 	DeltaTime         float32
 	Frame             int64
 	GridSize          float32
+	TextSupersampling int
 	ScreenSize        Point
 	ScreenSizePrev    Point
 	ScreenSizeChanged bool

--- a/gui.go
+++ b/gui.go
@@ -2139,24 +2139,16 @@ func (label *Label) Draw() {
 
 	if label.RendererResult != nil && len(label.Text) > 0 {
 
-		baseline := float32(globals.Font.Ascent()) / 4
-
 		w := int32(label.RendererResult.Image.Size.X)
-
-		if w > int32(label.Rect.W) {
-			w = int32(label.Rect.W)
-		}
 
 		h := int32(label.RendererResult.Image.Size.Y)
 
-		if h > int32(label.Rect.H+baseline) {
-			h = int32(label.Rect.H + baseline)
-		}
-
 		src := &sdl.Rect{0, 0, w, h}
 
+		scaleup := float32(4)
+
 		// Floor the rectangle to avoid aliasing artifacts when rendering with nearest neighbour
-		newRect := &sdl.FRect{float32(math.Floor(float64(label.Rect.X + label.Offset.X))), float32(math.Floor(float64(label.Rect.Y + label.Offset.Y))), float32(w), float32(h)}
+		newRect := &sdl.FRect{float32(math.Floor(float64(label.Rect.X + label.Offset.X))), float32(math.Floor(float64(label.Rect.Y + label.Offset.Y))), float32(w) / scaleup, float32(h) / scaleup}
 
 		// newRect.Y -= baseline // Center it
 

--- a/gui.go
+++ b/gui.go
@@ -2145,7 +2145,7 @@ func (label *Label) Draw() {
 
 		src := &sdl.Rect{0, 0, w, h}
 
-		scaleup := float32(4)
+		scaleup := float32(globals.TextSupersampling);
 
 		// Floor the rectangle to avoid aliasing artifacts when rendering with nearest neighbour
 		newRect := &sdl.FRect{float32(math.Floor(float64(label.Rect.X + label.Offset.X))), float32(math.Floor(float64(label.Rect.Y + label.Offset.Y))), float32(w) / scaleup, float32(h) / scaleup}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func init() {
 	globals.Mouse.Dummy = &nm
 	globals.Resources = NewResourceBank()
 	globals.GridSize = 32
+	globals.TextSupersampling = 8
 	globals.InputText = []rune{}
 	globals.CopyBuffer = NewCopyBuffer()
 	globals.State = StateNeutral

--- a/textrenderer.go
+++ b/textrenderer.go
@@ -251,7 +251,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 		sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, "2")
 		finalW := globals.GridSize
 
-		scaleup := 4
+		scaleup := globals.TextSupersampling;
 		x := 0
 		y := 0
 
@@ -327,7 +327,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 			toRender = append(toRender, &renderPair{
 				Glyph: glyph,
-				Rect:  &sdl.FRect{float32(x * scaleup), float32(y * scaleup), float32(glyph.Width() * 4), float32(glyph.Height() * 4)},
+				Rect:  &sdl.FRect{float32(x * scaleup), float32(y * scaleup), float32(glyph.Width() * int32(scaleup)), float32(glyph.Height() * int32(scaleup))},
 			})
 
 			x += int(glyph.Width())

--- a/textrenderer.go
+++ b/textrenderer.go
@@ -251,6 +251,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 		sdl.SetHint(sdl.HINT_RENDER_SCALE_QUALITY, "2")
 		finalW := globals.GridSize
 
+		scaleup := 4
 		x := 0
 		y := 0
 
@@ -261,7 +262,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 		type renderPair struct {
 			Glyph *Glyph
-			Rect  *sdl.Rect
+			Rect  *sdl.FRect
 		}
 
 		toRender := []*renderPair{}
@@ -326,7 +327,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 			toRender = append(toRender, &renderPair{
 				Glyph: glyph,
-				Rect:  &sdl.Rect{int32(x), int32(y), glyph.Width(), glyph.Height()},
+				Rect:  &sdl.FRect{float32(x * scaleup), float32(y * scaleup), float32(glyph.Width() * 4), float32(glyph.Height() * 4)},
 			})
 
 			x += int(glyph.Width())
@@ -353,7 +354,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 		lineIndex := 0
 
-		var lw int32
+		var lw float32
 
 		for _, ch := range toRender {
 			if ch == nil {
@@ -362,9 +363,9 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 			}
 
 			if horizontalAlignment == AlignCenter {
-				lw = int32((finalW - result.LineSizes[lineIndex].X) / 2)
+				lw = float32((finalW - result.LineSizes[lineIndex].X) / 2)
 			} else if horizontalAlignment == AlignRight {
-				lw = int32(finalW - result.LineSizes[lineIndex].X)
+				lw = float32(finalW - result.LineSizes[lineIndex].X)
 			}
 
 			ch.Rect.X += lw
@@ -375,7 +376,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 
 		// Now render
 
-		renderTexture.Recreate(int32(result.TextSize.X), int32(result.TextSize.Y))
+		renderTexture.Recreate(int32(result.TextSize.X) * int32(scaleup), int32(result.TextSize.Y) * int32(scaleup))
 
 		renderTexture.Texture.SetBlendMode(sdl.BLENDMODE_BLEND)
 
@@ -392,7 +393,7 @@ func (tr *TextRenderer) RenderText(text string, maxSize Point, horizontalAlignme
 			if r == nil {
 				continue
 			}
-			globals.Renderer.Copy(r.Glyph.Texture(), nil, r.Rect)
+			globals.Renderer.CopyF(r.Glyph.Texture(), nil, r.Rect)
 		}
 
 	}


### PR DESCRIPTION
I've made some changes locally to stop text from appearing blurry when at >100% zoom. I've referred to this a "text supersampling" in code and it's configurable in the main.go global variables (currently set to a factor of 8, but that can be tweaked)

Comparison screenshots at 1440p fullscreen:
Before/after with default font:

![before_defaultfont](https://github.com/SolarLune/masterplan/assets/3966523/ccd69163-83e5-46ed-a5c5-d55db39821d7)
![after_defaultfont](https://github.com/SolarLune/masterplan/assets/3966523/cb565f3b-818b-4053-b3aa-3b3f2fa1c4f3)

Before/after with pixel font (excel.ttf):

![before_pixelfont](https://github.com/SolarLune/masterplan/assets/3966523/1cff9149-46a0-4a33-ab97-0bbfb7572a75)
![after_pixelfont](https://github.com/SolarLune/masterplan/assets/3966523/5402e5cc-4535-4932-bcf9-eb0780945684)

It works by making the rendertexture created by `textRenderer.RenderText` a lot larger, and then scaling it back down to the correct size in the label rendering logic in `Draw()` in gui.go. Before this change, `textRenderer.RenderText` was creating renderTextures that were only 32px tall, which made the text look blurry. 

This PR also increased the size of the glyphs from 48 to 128 in common.go (128 might be overkill, could probably be reduced a bit without causing much issue)

Hope this helps!