### PR TITLE
Fix+Overhaul CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,17 +21,17 @@ jobs:
 
       - name: Build
         run: |
-          go run build_script/build.go -b -c
+          go run build_script/build.go -b
 
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-0.9-Release-amd64
-          path: ./bin/linux-0.9-Release-amd64.tar.gz
+          path: ./bin/linux-0.9-Release-amd64
 
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-0.9-Demo-amd64
-          path: ./bin/linux-0.9-Demo-amd64.tar.gz
+          path: ./bin/linux-0.9-Demo-amd64
 
       # - name: Test
       #   run: timeout 10s go run .
@@ -56,17 +56,17 @@ jobs:
 
       - name: Build
         run: |
-          go run build_script/build.go -b -c
+          go run build_script/build.go -b
 
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-0.9-Release-amd64
-          path: ./bin/windows-0.9-Release-amd64.zip
+          path: ./bin/windows-0.9-Release-amd64
 
       - uses: actions/upload-artifact@v4
         with:
           name: Windows-0.9-Demo-amd64
-          path: ./bin/windows-0.9-Demo-amd64.zip
+          path: ./bin/windows-0.9-Demo-amd64
 
       # - name: Test
       #   run: |
@@ -94,19 +94,15 @@ jobs:
         run: |
           dylibbundler -od -b -x ./bin/darwin-0.9-Release-amd64/MasterPlan.app/Contents/MacOS/masterplan -d ./bin/darwin-0.9-Release-amd64/MasterPlan.app/Contents/libs -p @executable_path/../libs
           dylibbundler -od -b -x ./bin/darwin-0.9-Demo-amd64/MasterPlan.app/Contents/MacOS/masterplan -d ./bin/darwin-0.9-Demo-amd64/MasterPlan.app/Contents/libs -p @executable_path/../libs
-
-      - name: Compress
-        run: go run build_script/build.go -c
-
       - uses: actions/upload-artifact@v4
         with:
           name: MacOS-0.9-Release-amd64
-          path: ./bin/darwin-0.9-Release-amd64.tar.gz
+          path: ./bin/darwin-0.9-Release-amd64
 
       - uses: actions/upload-artifact@v4
         with:
           name: MacOS-0.9-Demo-amd64
-          path: ./bin/darwin-0.9-Demo-amd64.tar.gz
+          path: ./bin/darwin-0.9-Demo-amd64
 
       # - name: Test
       #   run: go run .
@@ -131,19 +127,15 @@ jobs:
         run: |
           dylibbundler -od -b -x ./bin/darwin-0.9-Release-arm64/MasterPlan.app/Contents/MacOS/masterplan -d ./bin/darwin-0.9-Release-arm64/MasterPlan.app/Contents/libs -p @executable_path/../libs
           dylibbundler -od -b -x ./bin/darwin-0.9-Demo-arm64/MasterPlan.app/Contents/MacOS/masterplan -d ./bin/darwin-0.9-Demo-arm64/MasterPlan.app/Contents/libs -p @executable_path/../libs
-
-      - name: Compress
-        run: go run build_script/build.go -c
-
       - uses: actions/upload-artifact@v4
         with:
           name: MacOS-0.9-Release-arm64
-          path: bin/darwin-0.9-Release-arm64.tar.gz
+          path: bin/darwin-0.9-Release-arm64
 
       - uses: actions/upload-artifact@v4
         with:
           name: MacOS-0.9-Demo-arm64
-          path: bin/darwin-0.9-Demo-arm64.tar.gz
+          path: bin/darwin-0.9-Demo-arm64
 
       # - name: Test
       #   run: go run .

--- a/build_script/build.go
+++ b/build_script/build.go
@@ -37,7 +37,7 @@ func build(baseDir string, releaseMode string, targetOS, targetArch string) {
 		panic(err)
 	}
 
-	copyTo("changelog.txt", filepath.Join(baseDir, "changelog.txt"))
+	copyTo("changelog.md", filepath.Join(baseDir, "changelog.md"))
 
 	if forMac {
 		baseDir = filepath.Join(baseDir, "MasterPlan.app", "Contents", "MacOS")

--- a/build_script/build.go
+++ b/build_script/build.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
+	stdzip "archive/zip"
 	"github.com/mholt/archives"
 	"github.com/otiai10/copy"
 )
@@ -169,35 +169,48 @@ func compress() {
 		version := versions[i]
 		ending := versions[i+1]
 
-		// We want to create separate archives for each version (e.g. release and demo)
-		files, err := archives.FilesFromDisk(ctx, nil, map[string]string{
-			version: version + ending,
-		})
-
-		if err != nil {
-			panic(err)
-		}
-
-		format := archives.CompressedArchive{
-			Compression: archives.Gz{},
-			Archival:    archives.Tar{},
-		}
-
-		out, err := os.Create(version + ending)
-		if err != nil {
-			panic(err)
-		}
-
-		defer out.Close()
-
-		err = format.Archive(ctx, out, files)
-		if err != nil {
-			panic(err)
-		}
+		// Use helper to write the archive for this version+ending
+		writeArchive(ctx, version, ending)
 
 	}
 
 	fmt.Println("<Build successfully compressed!>")
+
+}
+
+// writes an archive for the given directory `version` using the provided ending.
+func writeArchive(ctx context.Context, version, ending string) {
+
+	files, err := archives.FilesFromDisk(ctx, nil, map[string]string{
+		version: version + ending,
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	out, err := os.Create(version + ending)
+	if err != nil {
+		panic(err)
+	}
+	defer out.Close()
+
+	var format archives.CompressedArchive
+	if ending == ".zip" {
+		format = archives.CompressedArchive{
+			Archival: archives.Zip{Compression: stdzip.Deflate},
+		}
+	} else {
+		format = archives.CompressedArchive{
+			Compression: archives.Gz{},
+			Archival:    archives.Tar{},
+		}
+	}
+
+	err = format.Archive(ctx, out, files)
+	if err != nil {
+		panic(err)
+	}
 
 }
 


### PR DESCRIPTION
I noticed the CI was failing because changelog.txt got renamed to changelog.md. I made a small change to the build script to fix this.

I then noticed the windows artifacts are rather confusing - they are a targz (named zip). This was throwing off extractors (windows thought it was a password-protected zip), until renamed to .tar.gz.

I fixed this, but then realized, the artifacts are all zips. With either targz or zip archives inside them.
GitHub actions seems to be unable to upload a unzipped file as an artifact, it's always a zip, with other archives inside. So either way you need a zip extractor, making its pointless to compress everything to targz.
This makes my second commit somewhat redundant, but I figured it was better to fix the confusion when archiving anyway.
I can drop the last commit if it's undesired.