### PR TITLE
Apple M3 build success.

### DIFF
--- a/build_script/build.go
+++ b/build_script/build.go
@@ -37,7 +37,7 @@ func build(baseDir string, releaseMode string, targetOS, targetArch string) {
 		panic(err)
 	}
 
-	copyTo("changelog.txt", filepath.Join(baseDir, "changelog.txt"))
+	copyTo("changelog.md", filepath.Join(baseDir, "changelog.md"))
 
 	if forMac {
 		baseDir = filepath.Join(baseDir, "MasterPlan.app", "Contents", "MacOS")

--- a/sound.go
+++ b/sound.go
@@ -190,7 +190,11 @@ var uiSounds = map[UISoundType][]string{}
 
 func init() {
 
-	filepath.Walk("assets/sounds/snddev_sine/", func(path string, info fs.FileInfo, err error) error {
+	filepath.Walk(LocalRelativePath("assets/sounds/snddev_sine/"), func(path string, info fs.FileInfo, err error) error {
+
+		if err != nil {
+			log.Fatalln("Error loading sound assets: ", err)
+		}
 
 		if info.IsDir() {
 			return nil


### PR DESCRIPTION
Two changes made building on an Apple M3 successful.

`changelog` file extension seems to have changed.

Sound assets are loaded relative to CWD even in Release Mode.