### PR TITLE
Add support to acute/grave dead keys

### DIFF
--- a/events.go
+++ b/events.go
@@ -352,6 +352,8 @@ func LoadCursors() {
 
 }
 
+var activeAccent = STATE_NONE
+
 func handleEvents() {
 
 	globals.Mouse.wheel = 0
@@ -425,11 +427,33 @@ func handleEvents() {
 			wheel := event.Y
 			globals.Mouse.wheel = int32(wheel)
 
-			// TODO: Add IME support; should be doable but I'm not sure how right now
+		// TODO: Add IME support; should be doable but I'm not sure how right now
+
+		case sdl.EVENT_TEXT_EDITING:
+			event := baseEvent.TextEditingEvent()
+
+			if event.Text == "`" {
+				activeAccent = STATE_GRAVE
+			} else if event.Text == "´" {
+				activeAccent = STATE_ACUTE
+			}
 
 		case sdl.EVENT_TEXT_INPUT:
+			input := baseEvent.TextInputEvent().Text
 
-			globals.InputText = append(globals.InputText, []rune(baseEvent.TextInputEvent().Text)...)
+			if activeAccent == STATE_ACUTE {
+				if accented, exists := acuteMap[input]; exists {
+					input = accented
+				}
+				activeAccent = STATE_NONE
+			} else if activeAccent == STATE_GRAVE {
+				if accented, exists := graveMap[input]; exists {
+					input = accented
+				}
+				activeAccent = STATE_NONE
+			}
+
+			globals.InputText = append(globals.InputText, []rune(input)...)
 
 		case sdl.EVENT_RENDER_DEVICE_RESET:
 			fallthrough

--- a/inputConstants.go
+++ b/inputConstants.go
@@ -1,0 +1,16 @@
+package main
+
+const (
+	STATE_NONE = iota
+	STATE_ACUTE
+	STATE_GRAVE
+)
+
+var acuteMap = map[string]string{
+	"a": "á", "e": "é", "i": "í", "o": "ó", "u": "ú",
+	"A": "Á", "E": "É", "I": "Í", "O": "Ó", "U": "Ú",
+}
+var graveMap = map[string]string{
+	"a": "à", "e": "è", "i": "ì", "o": "ò", "u": "ù",
+	"A": "À", "E": "È", "I": "Ì", "O": "Ò", "U": "Ù",
+}


### PR DESCRIPTION
Add support to acute (´) and grave (`) accents dead keys, since it's needed for things like Spanish keyboard layout and wasn't being handled.